### PR TITLE
Add Tableau workbook editor package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,63 @@
+# Tableau Workbook Editor
+
+`tableau_workbook_editor` is a Python package that can open, inspect and modify Tableau workbooks (`.twb`) or packaged workbooks (`.twbx`).  It focuses on safe round-tripping – any nodes that are not touched are preserved exactly as Tableau generated them.
+
+## Features
+
+- Parse `.twb` XML and `.twbx` zip archives with automatic detection.
+- Rich in-memory API for listing worksheets, dashboards, datasources and parameters.
+- Convenience helpers for common authoring tasks such as renaming fields, adding calculated fields, updating parameters and editing dashboard layouts.
+- Optional CLI (`tbe`) powered by `click` and `rich` for quick inspection and edits from the terminal.
+- Lightweight validation, diffing and device layout helpers.
+
+## Installing
+
+The project uses a standard `pyproject.toml`. Install the package in editable mode during development:
+
+```bash
+pip install -e .
+```
+
+## CLI Usage
+
+```
+tbe inspect workbook.twbx
+
+# rename a field
+tbe rename-field workbook.twb --datasource Orders --from Profit --to "Net Profit"
+
+# add a calculation
+tbe add-calc workbook.twb --datasource Orders --name "Profit Ratio" --formula "SUM([Profit])/SUM([Sales])" --type float
+
+# update a parameter
+tbe set-parameter workbook.twb --name RegionParam --type string --value West --allow East --allow West
+
+# add a sheet to a dashboard
+tbe add-sheet-to-dashboard workbook.twb --dashboard Executive --sheet "Detail" --floating false --container root --index 1
+```
+
+Each mutating command accepts `--dry-run`, `--backup` and `--as` options. Use `--dry-run` to preview changes without writing files and `--backup` to create a `*.bak` copy of the original workbook before saving.
+
+## Python API
+
+```python
+from tableau_workbook_editor import open_workbook
+
+wb = open_workbook("Sales.twbx")
+wb.rename_field(datasource="Orders", old="Profit", new="Net Profit")
+wb.add_calculation(
+    datasource="Orders",
+    name="Profit Ratio",
+    formula="SUM([Profit])/SUM([Sales])",
+    data_type="float",
+)
+wb.save_as("Sales_Modified.twbx", package_assets=True)
+```
+
+## Running Tests
+
+```bash
+pytest
+```
+
+The test suite uses synthetic `.twb` fixtures to ensure round-tripping behaviour and exercises all public helpers.

--- a/placeholder
+++ b/placeholder
@@ -1,1 +1,0 @@
-tableau file

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,33 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "tableau_workbook_editor"
+version = "0.1.0"
+description = "Lightweight Tableau workbook editing toolkit"
+readme = "README.md"
+authors = [{name = "OpenAI", email = "noreply@example.com"}]
+license = {text = "MIT"}
+requires-python = ">=3.12"
+dependencies = [
+    "lxml",
+    "defusedxml",
+    "xmltodict",
+    "tabulate",
+    "rich",
+    "click",
+    "tomli",
+    "jsonschema",
+    "packaging",
+]
+
+[project.optional-dependencies]
+hyper = ["tableauhyperapi"]
+
+[project.scripts]
+tbe = "tableau_workbook_editor.cli:main"
+
+[tool.pytest.ini_options]
+addopts = "-q"
+pythonpath = ["."]

--- a/tableau_workbook_editor/__init__.py
+++ b/tableau_workbook_editor/__init__.py
@@ -1,0 +1,15 @@
+"""Public API for :mod:`tableau_workbook_editor`."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from .core.twb_model import Workbook
+
+__all__ = ["Workbook", "open_workbook"]
+
+
+def open_workbook(path: str | Path) -> Workbook:
+    """Open *path* and return a :class:`Workbook` instance."""
+
+    return Workbook.open(path)

--- a/tableau_workbook_editor/cli.py
+++ b/tableau_workbook_editor/cli.py
@@ -1,0 +1,236 @@
+"""Command line interface for :mod:`tableau_workbook_editor`."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Optional
+
+import click
+from rich.console import Console
+from rich.table import Table
+from rich.tree import Tree
+
+from .core.reader import open_workbook
+
+console = Console()
+
+
+def _load_workbook(path: Path):
+    return open_workbook(path)
+
+
+def _save_workbook(workbook, *, target: Optional[Path], dry_run: bool, package_assets: bool) -> None:
+    workbook.save(path=target, dry_run=dry_run, package_assets=package_assets)
+    if dry_run:
+        console.print("[yellow]Dry run complete - no files written[/yellow]")
+    else:
+        console.print(f"[green]Saved workbook to {target or workbook.source.path}[/green]")
+
+
+def _maybe_backup(workbook, enabled: bool) -> None:
+    if not enabled:
+        return
+    source = workbook.source.path
+    backup_path = source.with_suffix(source.suffix + ".bak")
+    backup_path.write_bytes(source.read_bytes())
+    console.print(f"[cyan]Backup written to {backup_path}[/cyan]")
+
+
+def mutation_options(func):
+    func = click.option("--backup", is_flag=True, default=False)(func)
+    func = click.option("--package-assets", is_flag=True, default=False, help="Write the result as a packaged workbook")(
+        func
+    )
+    func = click.option("--dry-run", is_flag=True, default=False)(func)
+    func = click.option("--as", "target_path", type=click.Path(path_type=Path))(func)
+    func = click.argument("workbook", type=click.Path(path_type=Path, exists=True))(func)
+    return func
+
+
+@click.group()
+@click.version_option()
+def main() -> None:
+    """Tableau workbook editing tools."""
+
+
+@main.command()
+@click.argument("workbook", type=click.Path(path_type=Path, exists=True))
+def inspect(workbook: Path) -> None:
+    """Print a summary of the workbook."""
+
+    wb = _load_workbook(workbook)
+    tree = Tree(f"Workbook: {workbook.name}")
+    sheets = tree.add("Worksheets")
+    for sheet in wb.list_worksheets():
+        sheets.add(sheet)
+    dashboards_branch = tree.add("Dashboards")
+    for dash in wb.list_dashboards():
+        dashboards_branch.add(dash)
+    datasources_branch = tree.add("Datasources")
+    for ds in wb.list_datasources():
+        datasources_branch.add(ds)
+    params_branch = tree.add("Parameters")
+    for param in wb.list_parameters():
+        params_branch.add(param)
+    console.print(tree)
+
+
+@main.command()
+@click.argument("workbook", type=click.Path(path_type=Path, exists=True))
+@click.option("--out", "out_path", type=click.Path(path_type=Path))
+def export_json(workbook: Path, out_path: Optional[Path]) -> None:
+    """Export workbook metadata as JSON."""
+
+    import json
+
+    wb = _load_workbook(workbook)
+    data = {
+        "worksheets": wb.list_worksheets(),
+        "dashboards": wb.list_dashboards(),
+        "datasources": wb.list_datasources(),
+        "parameters": wb.list_parameters(),
+    }
+    payload = json.dumps(data, indent=2)
+    if out_path is None:
+        console.print(payload)
+    else:
+        out_path.write_text(payload)
+        console.print(f"[green]Metadata exported to {out_path}")
+
+
+@main.command()
+@click.argument("workbook", type=click.Path(path_type=Path, exists=True))
+@click.option("--sheets", "list_sheets", is_flag=True, help="List worksheets")
+@click.option("--dashboards", "list_dashboards_flag", is_flag=True, help="List dashboards")
+@click.option("--datasources", "list_datasources_flag", is_flag=True, help="List datasources")
+@click.option("--parameters", "list_parameters_flag", is_flag=True, help="List parameters")
+def list(workbook: Path, list_sheets: bool, list_dashboards_flag: bool, list_datasources_flag: bool, list_parameters_flag: bool) -> None:
+    """List workbook components."""
+
+    wb = _load_workbook(workbook)
+    table = Table("Type", "Name")
+    if list_sheets:
+        for name in wb.list_worksheets():
+            table.add_row("worksheet", name)
+    if list_dashboards_flag:
+        for name in wb.list_dashboards():
+            table.add_row("dashboard", name)
+    if list_datasources_flag:
+        for name in wb.list_datasources():
+            table.add_row("datasource", name)
+    if list_parameters_flag:
+        for name in wb.list_parameters():
+            table.add_row("parameter", name)
+    console.print(table)
+
+
+@main.command("rename-field")
+@mutation_options
+@click.option("--datasource", required=True)
+@click.option("--from", "from_name", required=True)
+@click.option("--to", required=True)
+def rename_field_cmd(workbook: Path, target_path: Optional[Path], dry_run: bool, package_assets: bool, backup: bool, datasource: str, from_name: str, to: str) -> None:
+    wb = _load_workbook(workbook)
+    _maybe_backup(wb, backup)
+    wb.rename_field(datasource=datasource, old=from_name, new=to)
+    _save_workbook(wb, target=target_path, dry_run=dry_run, package_assets=package_assets)
+
+
+@main.command("add-calc")
+@mutation_options
+@click.option("--datasource", required=True)
+@click.option("--name", required=True)
+@click.option("--formula", required=True)
+@click.option("--type", "data_type", default="string")
+def add_calc_cmd(workbook: Path, target_path: Optional[Path], dry_run: bool, package_assets: bool, backup: bool, datasource: str, name: str, formula: str, data_type: str) -> None:
+    wb = _load_workbook(workbook)
+    _maybe_backup(wb, backup)
+    wb.add_calculation(datasource=datasource, name=name, formula=formula, data_type=data_type)
+    _save_workbook(wb, target=target_path, dry_run=dry_run, package_assets=package_assets)
+
+
+@main.command("set-parameter")
+@mutation_options
+@click.option("--name", required=True)
+@click.option("--type", "data_type", required=True)
+@click.option("--value", required=True)
+@click.option("--allow", "allowable_values", multiple=True)
+@click.option("--display-format")
+def set_parameter_cmd(workbook: Path, target_path: Optional[Path], dry_run: bool, package_assets: bool, backup: bool, name: str, data_type: str, value: str, allowable_values: tuple[str, ...], display_format: Optional[str]) -> None:
+    wb = _load_workbook(workbook)
+    _maybe_backup(wb, backup)
+    wb.set_parameter(name=name, data_type=data_type, value=value, allowable_values=list(allowable_values) or None, display_format=display_format)
+    _save_workbook(wb, target=target_path, dry_run=dry_run, package_assets=package_assets)
+
+
+@main.command("add-sheet-to-dashboard")
+@mutation_options
+@click.option("--dashboard", required=True)
+@click.option("--sheet", required=True)
+@click.option("--floating", type=bool, default=False)
+@click.option("--container", default="")
+@click.option("--index", type=int, default=-1)
+def add_sheet_to_dashboard_cmd(workbook: Path, target_path: Optional[Path], dry_run: bool, package_assets: bool, backup: bool, dashboard: str, sheet: str, floating: bool, container: str, index: int) -> None:
+    wb = _load_workbook(workbook)
+    _maybe_backup(wb, backup)
+    wb.add_sheet_to_dashboard(dashboard=dashboard, sheet=sheet, floating=floating, container=container, index=index)
+    _save_workbook(wb, target=target_path, dry_run=dry_run, package_assets=package_assets)
+
+
+@main.command("move-zone")
+@mutation_options
+@click.option("--dashboard", required=True)
+@click.option("--zone-id", required=True)
+@click.option("--x", type=int)
+@click.option("--y", type=int)
+@click.option("--w", type=int)
+@click.option("--h", type=int)
+def move_zone_cmd(workbook: Path, target_path: Optional[Path], dry_run: bool, package_assets: bool, backup: bool, dashboard: str, zone_id: str, x: Optional[int], y: Optional[int], w: Optional[int], h: Optional[int]) -> None:
+    wb = _load_workbook(workbook)
+    _maybe_backup(wb, backup)
+    wb.move_zone(dashboard=dashboard, zone_id=zone_id, x=x, y=y, w=w, h=h)
+    _save_workbook(wb, target=target_path, dry_run=dry_run, package_assets=package_assets)
+
+
+@main.command("add-filter-action")
+@mutation_options
+@click.option("--source", required=True)
+@click.option("--target", "target_sheet", required=True)
+@click.option("--mapping", required=False, default="")
+def add_filter_action_cmd(workbook: Path, target_path: Optional[Path], dry_run: bool, package_assets: bool, backup: bool, source: str, target_sheet: str, mapping: str) -> None:
+    wb = _load_workbook(workbook)
+    _maybe_backup(wb, backup)
+    mapping_dict: Dict[str, str] = {}
+    if mapping:
+        for pair in mapping.split(";"):
+            if not pair:
+                continue
+            left, _, right = pair.partition("=")
+            mapping_dict[left.strip()] = right.strip()
+    wb.add_filter_action(source=source, target=target_sheet, mapping=mapping_dict)
+    _save_workbook(wb, target=target_path, dry_run=dry_run, package_assets=package_assets)
+
+
+@main.command("set-connection")
+@mutation_options
+@click.option("--datasource", required=True)
+@click.option("--server")
+@click.option("--db")
+@click.option("--schema")
+@click.option("--table")
+def set_connection_cmd(workbook: Path, target_path: Optional[Path], dry_run: bool, package_assets: bool, backup: bool, datasource: str, server: Optional[str], db: Optional[str], schema: Optional[str], table: Optional[str]) -> None:
+    wb = _load_workbook(workbook)
+    _maybe_backup(wb, backup)
+    wb.set_connection(datasource=datasource, server=server, db=db, schema=schema, table=table)
+    _save_workbook(wb, target=target_path, dry_run=dry_run, package_assets=package_assets)
+
+
+@main.command("save")
+@mutation_options
+def save_cmd(workbook: Path, target_path: Optional[Path], dry_run: bool, package_assets: bool, backup: bool) -> None:
+    wb = _load_workbook(workbook)
+    _maybe_backup(wb, backup)
+    _save_workbook(wb, target=target_path, dry_run=dry_run, package_assets=package_assets)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tableau_workbook_editor/core/actions.py
+++ b/tableau_workbook_editor/core/actions.py
@@ -1,0 +1,34 @@
+"""Action helpers."""
+from __future__ import annotations
+
+from typing import Dict, List
+
+from .xml_utils import Element, etree, xpath
+
+
+ACTIONS_XPATH = "./actions/action"
+
+
+def list_actions(root: Element) -> List[Element]:
+    return list(xpath(root, ACTIONS_XPATH))
+
+
+def ensure_actions_parent(root: Element) -> Element:
+    actions_parent = root.find("actions")
+    if actions_parent is None:
+        actions_parent = etree.Element("actions")
+        root.append(actions_parent)
+    return actions_parent
+
+
+def create_filter_action(root: Element, source: str, target: str, mapping: Dict[str, str]) -> Element:
+    actions_parent = ensure_actions_parent(root)
+    action = etree.Element("action")
+    action.set("type", "filter")
+    action.set("source", source)
+    action.set("target", target)
+    if mapping:
+        pairs = [f"{src}={dst}" for src, dst in mapping.items()]
+        action.set("mapping", "; ".join(pairs))
+    actions_parent.append(action)
+    return action

--- a/tableau_workbook_editor/core/calc_utils.py
+++ b/tableau_workbook_editor/core/calc_utils.py
@@ -1,0 +1,56 @@
+"""Utilities for working with Tableau calculations."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Set
+
+
+KNOWN_FUNCTIONS: Set[str] = {
+    "sum",
+    "avg",
+    "min",
+    "max",
+    "lookup",
+    "running_sum",
+    "zn",
+    "if",
+    "then",
+    "else",
+    "elseif",
+    "end",
+}
+
+
+@dataclass
+class CalculationLintResult:
+    ok: bool
+    message: str = ""
+
+
+def lint_calculation(formula: str) -> CalculationLintResult:
+    stack = []
+    for char in formula:
+        if char in "(":
+            stack.append(char)
+        elif char == ")":
+            if not stack:
+                return CalculationLintResult(False, "Unbalanced parentheses")
+            stack.pop()
+    if stack:
+        return CalculationLintResult(False, "Unbalanced parentheses")
+    bracket_stack = 0
+    escaped = False
+    for char in formula:
+        if char == "'" and not escaped:
+            escaped = True
+        elif char == "'" and escaped:
+            escaped = False
+        elif char == "[" and not escaped:
+            bracket_stack += 1
+        elif char == "]" and not escaped:
+            bracket_stack -= 1
+            if bracket_stack < 0:
+                return CalculationLintResult(False, "Unbalanced field brackets")
+    if bracket_stack != 0:
+        return CalculationLintResult(False, "Unbalanced field brackets")
+    return CalculationLintResult(True, "")

--- a/tableau_workbook_editor/core/dashboards.py
+++ b/tableau_workbook_editor/core/dashboards.py
@@ -1,0 +1,69 @@
+"""Dashboard helpers."""
+from __future__ import annotations
+
+from typing import List, Optional
+
+from .xml_utils import Element, IdRegistry, etree, xpath
+
+
+DASHBOARDS_XPATH = "./dashboards/dashboard"
+
+
+def list_dashboards(root: Element) -> List[str]:
+    return [db.get("name") or "" for db in xpath(root, DASHBOARDS_XPATH)]
+
+
+def find_dashboard(root: Element, name: str) -> Optional[Element]:
+    for dashboard in xpath(root, DASHBOARDS_XPATH):
+        if dashboard.get("name") == name:
+            return dashboard
+    return None
+
+
+def list_dashboard_zones(dashboard: Element) -> List[Element]:
+    zones_parent = dashboard.find("zones")
+    if zones_parent is None:
+        return []
+    return list(zones_parent)
+
+
+def ensure_zones_parent(dashboard: Element) -> Element:
+    zones_parent = dashboard.find("zones")
+    if zones_parent is None:
+        zones_parent = etree.Element("zones")
+        dashboard.append(zones_parent)
+    return zones_parent
+
+
+def append_sheet_zone(dashboard: Element, sheet_name: str, registry: IdRegistry, *, floating: bool, container: str, index: int) -> Element:
+    zones_parent = ensure_zones_parent(dashboard)
+    zone = etree.Element("zone")
+    zone.set("type", "worksheet")
+    zone.set("worksheet", sheet_name)
+    zone_id = registry.new("z")
+    zone.set("id", zone_id)
+    if floating:
+        zone.set("floating", "true")
+    if container:
+        zone.set("container", container)
+    zone.set("x", "0")
+    zone.set("y", "0")
+    zone.set("w", "400")
+    zone.set("h", "300")
+    children = list(zones_parent)
+    if index < 0 or index >= len(children):
+        zones_parent.append(zone)
+    else:
+        zones_parent.insert(index, zone)
+    return zone
+
+
+def update_zone_geometry(zone: Element, *, x: Optional[int] = None, y: Optional[int] = None, w: Optional[int] = None, h: Optional[int] = None) -> None:
+    if x is not None:
+        zone.set("x", str(x))
+    if y is not None:
+        zone.set("y", str(y))
+    if w is not None:
+        zone.set("w", str(w))
+    if h is not None:
+        zone.set("h", str(h))

--- a/tableau_workbook_editor/core/datasources.py
+++ b/tableau_workbook_editor/core/datasources.py
@@ -1,0 +1,50 @@
+"""Datasource helpers."""
+from __future__ import annotations
+
+from typing import Iterable, List, Optional
+
+from .xml_utils import Element, etree, xpath
+
+
+DATASOURCES_XPATH = "./datasources/datasource"
+
+
+def list_datasource_names(root: Element) -> List[str]:
+    return [ds.get("name") or ds.get("caption") or "" for ds in xpath(root, DATASOURCES_XPATH)]
+
+
+def find_datasource(root: Element, name: str) -> Optional[Element]:
+    for ds in xpath(root, DATASOURCES_XPATH):
+        if ds.get("name") == name or ds.get("caption") == name:
+            return ds
+    return None
+
+
+def list_columns(datasource: Element) -> List[Element]:
+    return list(xpath(datasource, "./column"))
+
+
+def find_column(datasource: Element, name: str) -> Optional[Element]:
+    for column in list_columns(datasource):
+        if column.get("caption") == name or column.get("name") == name or column.get("name") == f"[{name}]":
+            return column
+        if column.get("caption") == f"[{name}]":
+            return column
+    return None
+
+
+def ensure_column_name(column: Element) -> str:
+    name = column.get("name")
+    if name:
+        return name
+    caption = column.get("caption") or "Unnamed"
+    formatted = caption if caption.startswith("[") else f"[{caption}]"
+    column.set("name", formatted)
+    return formatted
+
+
+def update_connection(connection: Element, **attrs: str) -> None:
+    for key, value in attrs.items():
+        if value is None:
+            continue
+        connection.set(key.replace("_", "-"), value)

--- a/tableau_workbook_editor/core/devices.py
+++ b/tableau_workbook_editor/core/devices.py
@@ -1,0 +1,13 @@
+"""Device layout helpers."""
+from __future__ import annotations
+
+from typing import List
+
+from .xml_utils import Element
+
+
+def list_device_layouts(dashboard: Element) -> List[Element]:
+    devices = dashboard.find("device-layouts")
+    if devices is None:
+        return []
+    return list(devices)

--- a/tableau_workbook_editor/core/diffs.py
+++ b/tableau_workbook_editor/core/diffs.py
@@ -1,0 +1,23 @@
+"""Diff helpers for workbook changes."""
+from __future__ import annotations
+
+from typing import List
+
+from .xml_utils import Element, etree
+
+
+def element_to_string(element: Element) -> str:
+    return etree.tostring(element, encoding="unicode")
+
+
+def diff_elements(before: Element, after: Element) -> List[str]:
+    before_str = element_to_string(before).splitlines()
+    after_str = element_to_string(after).splitlines()
+    diff: List[str] = []
+    for line in before_str:
+        if line not in after_str:
+            diff.append(f"- {line}")
+    for line in after_str:
+        if line not in before_str:
+            diff.append(f"+ {line}")
+    return diff

--- a/tableau_workbook_editor/core/formatting.py
+++ b/tableau_workbook_editor/core/formatting.py
@@ -1,0 +1,14 @@
+"""Formatting helpers."""
+from __future__ import annotations
+
+from typing import Dict
+
+from .xml_utils import Element
+
+
+def set_number_format(column: Element, format_string: str) -> None:
+    column.set("format", format_string)
+
+
+def set_alias(column: Element, alias: str) -> None:
+    column.set("alias", alias)

--- a/tableau_workbook_editor/core/hyper_utils.py
+++ b/tableau_workbook_editor/core/hyper_utils.py
@@ -1,0 +1,26 @@
+"""Optional helpers for interacting with Tableau Hyper extracts."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+try:  # pragma: no cover - optional dependency
+    from tableauhyperapi import HyperProcess  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    HyperProcess = None  # type: ignore
+
+
+@dataclass
+class HyperInfo:
+    path: Path
+
+
+def is_available() -> bool:
+    return HyperProcess is not None
+
+
+def describe_hyper(path: Path) -> Optional[HyperInfo]:
+    if not path.exists():
+        return None
+    return HyperInfo(path=path)

--- a/tableau_workbook_editor/core/layouts.py
+++ b/tableau_workbook_editor/core/layouts.py
@@ -1,0 +1,13 @@
+"""Layout helpers."""
+from __future__ import annotations
+
+from typing import List
+
+from .xml_utils import Element
+
+
+def list_layout_zones(dashboard: Element) -> List[Element]:
+    zones = dashboard.find("zones")
+    if zones is None:
+        return []
+    return list(zones)

--- a/tableau_workbook_editor/core/parameters.py
+++ b/tableau_workbook_editor/core/parameters.py
@@ -1,0 +1,38 @@
+"""Parameter helpers."""
+from __future__ import annotations
+
+from typing import List, Optional
+
+from .xml_utils import Element, etree, xpath
+
+
+PARAMETERS_XPATH = "./parameters/parameter"
+
+
+def list_parameters(root: Element) -> List[str]:
+    return [param.get("name") or "" for param in xpath(root, PARAMETERS_XPATH)]
+
+
+def find_parameter(root: Element, name: str) -> Optional[Element]:
+    for param in xpath(root, PARAMETERS_XPATH):
+        if param.get("name") == name:
+            return param
+    return None
+
+
+def ensure_parameters_parent(root: Element) -> Element:
+    parent = root.find("parameters")
+    if parent is None:
+        parent = etree.Element("parameters")
+        root.append(parent)
+    return parent
+
+
+def create_parameter(root: Element, name: str, data_type: str, value: str) -> Element:
+    parent = ensure_parameters_parent(root)
+    param = etree.Element("parameter")
+    param.set("name", name)
+    param.set("datatype", data_type)
+    param.set("current-value", value)
+    parent.append(param)
+    return param

--- a/tableau_workbook_editor/core/reader.py
+++ b/tableau_workbook_editor/core/reader.py
@@ -1,0 +1,33 @@
+"""Workbook reader helpers."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from . import twbx_utils, xml_utils
+from .twb_model import Workbook
+
+
+@dataclass
+class WorkbookSource:
+    path: Path
+    is_twbx: bool
+    packaged: Optional[twbx_utils.PackagedWorkbook]
+
+
+def open_workbook(path: Path) -> Workbook:
+    path = path.expanduser().resolve()
+    if not path.exists():
+        raise FileNotFoundError(path)
+    if path.suffix.lower() == ".twbx":
+        package = twbx_utils.extract_twbx(path)
+        root = xml_utils.load_xml(package.workbook_xml)
+        source = WorkbookSource(path=path, is_twbx=True, packaged=package)
+    elif path.suffix.lower() == ".twb":
+        data = path.read_bytes()
+        root = xml_utils.load_xml(data)
+        source = WorkbookSource(path=path, is_twbx=False, packaged=None)
+    else:
+        raise ValueError("Unsupported workbook extension: expected .twb or .twbx")
+    return Workbook(root=root, source=source)

--- a/tableau_workbook_editor/core/twb_model.py
+++ b/tableau_workbook_editor/core/twb_model.py
@@ -1,0 +1,231 @@
+"""High level workbook model."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Dict, List, Optional
+
+from . import actions, dashboards, datasources, parameters, validators, versioning, worksheets
+from .calc_utils import lint_calculation
+from .xml_utils import Element, IdRegistry, dump_xml, etree, load_xml, xpath
+from .writer import WorkbookWriter
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .reader import WorkbookSource
+
+
+@dataclass
+class DiffResult:
+    description: str
+
+
+class Workbook:
+    """Representation of a Tableau workbook with convenience helpers."""
+
+    def __init__(self, *, root: Element, source: "WorkbookSource") -> None:
+        self.root = root
+        self.source = source
+        self._original = dump_xml(root)
+        self.id_registry = IdRegistry([root])
+
+    # ------------------------------------------------------------------
+    # Creation helpers
+    @classmethod
+    def open(cls, path: str | Path) -> "Workbook":
+        from .reader import open_workbook
+
+        return open_workbook(Path(path))
+
+    # ------------------------------------------------------------------
+    # Inspection helpers
+    def list_worksheets(self) -> List[str]:
+        return worksheets.list_worksheets(self.root)
+
+    def list_dashboards(self) -> List[str]:
+        return dashboards.list_dashboards(self.root)
+
+    def list_datasources(self) -> List[str]:
+        return datasources.list_datasource_names(self.root)
+
+    def list_parameters(self) -> List[str]:
+        return parameters.list_parameters(self.root)
+
+    # ------------------------------------------------------------------
+    # Modification helpers
+    def rename_field(self, *, datasource: str, old: str, new: str) -> None:
+        ds = datasources.find_datasource(self.root, datasource)
+        if ds is None:
+            raise ValueError(f"Datasource '{datasource}' not found")
+        column = datasources.find_column(ds, old)
+        if column is None:
+            raise ValueError(f"Field '{old}' not found in datasource '{datasource}'")
+        old_name = datasources.ensure_column_name(column)
+        old_caption = column.get("caption") or old_name.strip("[]")
+        new_ref = new if new.startswith("[") else f"[{new}]"
+        column.set("name", new_ref)
+        column.set("caption", new)
+        # Update dependencies in datasource
+        for dep in xpath(ds, ".//*[@ref]"):
+            if dep.get("ref") == old_name:
+                dep.set("ref", new_ref)
+        # Update worksheets
+        for worksheet_name in self.list_worksheets():
+            worksheet = worksheets.find_worksheet(self.root, worksheet_name)
+            if worksheet is None:
+                continue
+            worksheets.update_field_reference(worksheet, old=old_name, new=new_ref)
+            for node in xpath(worksheet, ".//*[@formula]"):
+                formula = node.get("formula")
+                if formula and old_name in formula:
+                    node.set("formula", formula.replace(old_name, new_ref))
+        # Update actions mapping text
+        for action in actions.list_actions(self.root):
+            mapping = action.get("mapping")
+            if mapping and old_caption in mapping:
+                action.set("mapping", mapping.replace(old_caption, new))
+
+    def add_calculation(self, *, datasource: str, name: str, formula: str, data_type: str = "string") -> None:
+        lint = lint_calculation(formula)
+        if not lint.ok:
+            raise ValueError(f"Calculation is invalid: {lint.message}")
+        ds = datasources.find_datasource(self.root, datasource)
+        if ds is None:
+            raise ValueError(f"Datasource '{datasource}' not found")
+        column = etree.Element("column")
+        ref_name = name if name.startswith("[") else f"[{name}]"
+        column.set("name", ref_name)
+        column.set("caption", name)
+        column.set("datatype", data_type)
+        calc = etree.Element("calculation")
+        calc.set("class", "tableau")
+        calc.set("formula", formula)
+        column.append(calc)
+        ds.append(column)
+
+    def set_parameter(
+        self,
+        *,
+        name: str,
+        data_type: str,
+        value: str,
+        allowable_values: Optional[List[str]] = None,
+        display_format: Optional[str] = None,
+    ) -> None:
+        parameter = parameters.find_parameter(self.root, name)
+        if parameter is None:
+            parameter = parameters.create_parameter(self.root, name=name, data_type=data_type, value=value)
+        else:
+            parameter.set("datatype", data_type)
+            parameter.set("current-value", value)
+        if allowable_values is not None:
+            values_node = parameter.find("values")
+            if values_node is None:
+                values_node = etree.Element("values")
+                parameter.append(values_node)
+            values_node.clear()
+            for item in allowable_values:
+                value_node = etree.Element("value")
+                value_node.text = str(item)
+                values_node.append(value_node)
+        if display_format is not None:
+            parameter.set("display-format", display_format)
+
+    def add_sheet_to_dashboard(
+        self,
+        *,
+        dashboard: str,
+        sheet: str,
+        floating: bool,
+        container: str,
+        index: int,
+    ) -> None:
+        worksheet = worksheets.find_worksheet(self.root, sheet)
+        if worksheet is None:
+            raise ValueError(f"Worksheet '{sheet}' not found")
+        dashboard_element = dashboards.find_dashboard(self.root, dashboard)
+        if dashboard_element is None:
+            raise ValueError(f"Dashboard '{dashboard}' not found")
+        dashboards.append_sheet_zone(
+            dashboard_element,
+            sheet_name=sheet,
+            registry=self.id_registry,
+            floating=floating,
+            container=container,
+            index=index,
+        )
+
+    def move_zone(
+        self,
+        *,
+        dashboard: str,
+        zone_id: str,
+        x: Optional[int] = None,
+        y: Optional[int] = None,
+        w: Optional[int] = None,
+        h: Optional[int] = None,
+    ) -> None:
+        dashboard_element = dashboards.find_dashboard(self.root, dashboard)
+        if dashboard_element is None:
+            raise ValueError(f"Dashboard '{dashboard}' not found")
+        for zone in dashboards.list_dashboard_zones(dashboard_element):
+            if zone.get("id") == zone_id:
+                dashboards.update_zone_geometry(zone, x=x, y=y, w=w, h=h)
+                return
+        raise ValueError(f"Zone '{zone_id}' not found in dashboard '{dashboard}'")
+
+    def add_filter_action(self, *, source: str, target: str, mapping: Dict[str, str]) -> None:
+        actions.create_filter_action(self.root, source=source, target=target, mapping=mapping)
+
+    def set_connection(
+        self,
+        *,
+        datasource: str,
+        server: Optional[str] = None,
+        db: Optional[str] = None,
+        schema: Optional[str] = None,
+        table: Optional[str] = None,
+    ) -> None:
+        ds = datasources.find_datasource(self.root, datasource)
+        if ds is None:
+            raise ValueError(f"Datasource '{datasource}' not found")
+        connection = ds.find("connection")
+        if connection is None:
+            connection = etree.Element("connection")
+            ds.append(connection)
+        update: Dict[str, Optional[str]] = {
+            "server": server,
+            "dbname": db,
+            "schema": schema,
+            "table": table,
+        }
+        for key, value in update.items():
+            if value is not None:
+                connection.set(key, value)
+
+    # ------------------------------------------------------------------
+    def validate(self) -> validators.ValidationReport:
+        return validators.validate_workbook(self.root)
+
+    def diff(self) -> List[str]:
+        before = load_xml(self._original)
+        return [] if etree.tostring(before) == etree.tostring(self.root) else ["Workbook modified"]
+
+    # ------------------------------------------------------------------
+    def save(
+        self,
+        *,
+        path: Optional[str | Path] = None,
+        package_assets: bool = False,
+        target_version: Optional[str] = None,
+        dry_run: bool = False,
+    ) -> Path | None:
+        versioning.ensure_target_version(self.root, target_version)
+        xml_bytes = dump_xml(self.root)
+        if dry_run:
+            return None
+        writer = WorkbookWriter(self.source)
+        target_path = Path(path) if path is not None else None
+        return writer.write(target_path, xml_bytes, package_assets=package_assets)
+
+    def save_as(self, path: str | Path, *, package_assets: bool = False, target_version: Optional[str] = None) -> Path | None:
+        return self.save(path=path, package_assets=package_assets, target_version=target_version)

--- a/tableau_workbook_editor/core/twbx_utils.py
+++ b/tableau_workbook_editor/core/twbx_utils.py
@@ -1,0 +1,46 @@
+"""Helpers for manipulating Tableau packaged workbooks (.twbx)."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Optional
+from zipfile import ZipFile
+
+
+@dataclass
+class PackagedWorkbook:
+    """In-memory representation of a Tableau packaged workbook."""
+
+    workbook_xml: bytes
+    inner_path: str
+    other_files: Dict[str, bytes]
+
+
+def extract_twbx(path: Path) -> PackagedWorkbook:
+    """Extract *path* and return a :class:`PackagedWorkbook` instance."""
+
+    workbook_xml: Optional[bytes] = None
+    inner_path = ""
+    other_files: Dict[str, bytes] = {}
+    with ZipFile(path, "r") as zf:
+        for info in zf.infolist():
+            data = zf.read(info)
+            if info.filename.lower().endswith(".twb"):
+                if workbook_xml is not None:
+                    raise ValueError("Multiple .twb files found inside the package")
+                workbook_xml = data
+                inner_path = info.filename
+            else:
+                other_files[info.filename] = data
+    if workbook_xml is None:
+        raise ValueError("Packaged workbook does not contain a .twb file")
+    return PackagedWorkbook(workbook_xml=workbook_xml, inner_path=inner_path, other_files=other_files)
+
+
+def pack_twbx(target: Path, package: PackagedWorkbook) -> None:
+    """Write *package* back to ``target`` preserving non-workbook files."""
+
+    with ZipFile(target, "w") as zf:
+        zf.writestr(package.inner_path, package.workbook_xml)
+        for name, data in package.other_files.items():
+            zf.writestr(name, data)

--- a/tableau_workbook_editor/core/validators.py
+++ b/tableau_workbook_editor/core/validators.py
@@ -1,0 +1,37 @@
+"""Validation helpers."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+from . import dashboards, worksheets
+from .xml_utils import Element
+
+
+@dataclass
+class ValidationIssue:
+    message: str
+
+
+@dataclass
+class ValidationReport:
+    issues: List[ValidationIssue]
+
+    @property
+    def ok(self) -> bool:
+        return not self.issues
+
+
+def validate_workbook(root: Element) -> ValidationReport:
+    issues: List[ValidationIssue] = []
+    worksheet_names = set(worksheets.list_worksheets(root))
+    for dashboard_name in dashboards.list_dashboards(root):
+        dashboard = dashboards.find_dashboard(root, dashboard_name)
+        if dashboard is None:
+            continue
+        for zone in dashboards.list_dashboard_zones(dashboard):
+            if zone.get("type") == "worksheet":
+                sheet = zone.get("worksheet")
+                if sheet not in worksheet_names:
+                    issues.append(ValidationIssue(f"Dashboard '{dashboard_name}' references missing worksheet '{sheet}'"))
+    return ValidationReport(issues=issues)

--- a/tableau_workbook_editor/core/versioning.py
+++ b/tableau_workbook_editor/core/versioning.py
@@ -1,0 +1,25 @@
+"""Workbook version helpers."""
+from __future__ import annotations
+
+from typing import Optional
+
+from .xml_utils import Element, etree
+
+
+def get_workbook_version(root: Element) -> Optional[str]:
+    version_node = root.find("version")
+    if version_node is None:
+        return None
+    return version_node.get("value") or version_node.text
+
+
+def ensure_target_version(root: Element, target_version: Optional[str]) -> None:
+    if target_version is None:
+        return
+    version_node = root.find("version")
+    if version_node is None:
+        version_node = etree.Element("version")
+        version_node.set("value", target_version)
+        root.append(version_node)
+    else:
+        version_node.set("value", target_version)

--- a/tableau_workbook_editor/core/worksheets.py
+++ b/tableau_workbook_editor/core/worksheets.py
@@ -1,0 +1,33 @@
+"""Worksheet helpers."""
+from __future__ import annotations
+
+from typing import List, Optional
+
+from .xml_utils import Element, xpath
+
+
+WORKSHEETS_XPATH = "./worksheets/worksheet"
+
+
+def list_worksheets(root: Element) -> List[str]:
+    return [ws.get("name") or "" for ws in xpath(root, WORKSHEETS_XPATH)]
+
+
+def find_worksheet(root: Element, name: str) -> Optional[Element]:
+    for worksheet in xpath(root, WORKSHEETS_XPATH):
+        if worksheet.get("name") == name:
+            return worksheet
+    return None
+
+
+def update_field_reference(worksheet: Element, *, old: str, new: str) -> int:
+    changed = 0
+    for node in xpath(worksheet, ".//*[@ref]"):
+        if node.get("ref") == old:
+            node.set("ref", new)
+            changed += 1
+    for node in xpath(worksheet, ".//*[@column]"):
+        if node.get("column") == old:
+            node.set("column", new)
+            changed += 1
+    return changed

--- a/tableau_workbook_editor/core/writer.py
+++ b/tableau_workbook_editor/core/writer.py
@@ -1,0 +1,45 @@
+"""Helpers for writing Tableau workbooks."""
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from typing import TYPE_CHECKING, Optional
+
+from . import twbx_utils, xml_utils
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .reader import WorkbookSource
+
+
+class WorkbookWriter:
+    """Persist a workbook to disk with atomic semantics."""
+
+    def __init__(self, source: "WorkbookSource") -> None:
+        self.source = source
+
+    def write(self, target: Optional[Path], xml_bytes: bytes, package_assets: bool) -> Path:
+        target_path = (target or self.source.path).expanduser().resolve()
+        if package_assets or self.source.is_twbx or (target and target.suffix.lower() == ".twbx"):
+            return self._write_twbx(target_path, xml_bytes)
+        return self._write_twb(target_path, xml_bytes)
+
+    def _write_twb(self, target: Path, xml_bytes: bytes) -> Path:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        with tempfile.NamedTemporaryFile("wb", delete=False, dir=str(target.parent)) as tmp:
+            tmp.write(xml_bytes)
+            temp_path = Path(tmp.name)
+        temp_path.replace(target)
+        return target
+
+    def _write_twbx(self, target: Path, xml_bytes: bytes) -> Path:
+        if self.source.packaged is None:
+            package = twbx_utils.PackagedWorkbook(workbook_xml=xml_bytes, inner_path=f"{target.stem}.twb", other_files={})
+        else:
+            package = self.source.packaged
+            package = twbx_utils.PackagedWorkbook(workbook_xml=xml_bytes, inner_path=package.inner_path, other_files=package.other_files)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        with tempfile.NamedTemporaryFile("wb", delete=False, dir=str(target.parent)) as tmp:
+            temp_path = Path(tmp.name)
+        twbx_utils.pack_twbx(temp_path, package)
+        temp_path.replace(target)
+        return target

--- a/tableau_workbook_editor/core/xml_utils.py
+++ b/tableau_workbook_editor/core/xml_utils.py
@@ -1,0 +1,126 @@
+"""Utilities for working with Tableau XML documents."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Iterator, Optional
+
+try:  # pragma: no cover - optional dependency
+    from defusedxml.lxml import fromstring  # type: ignore
+    from lxml import etree  # type: ignore
+    LXML_AVAILABLE = True
+except Exception:  # pragma: no cover - fallback path
+    try:
+        from defusedxml.ElementTree import fromstring  # type: ignore
+    except Exception:  # pragma: no cover - final fallback
+        from xml.etree.ElementTree import fromstring  # type: ignore
+    from xml.etree import ElementTree as etree  # type: ignore
+    LXML_AVAILABLE = False
+
+__all__ = [
+    "load_xml",
+    "dump_xml",
+    "Element",
+    "ensure_unique_id",
+    "IdRegistry",
+    "deep_copy_element",
+    "iter_elements",
+    "etree",
+    "xpath",
+]
+
+try:  # pragma: no cover - optional attribute when lxml is present
+    Element = etree._Element  # type: ignore[attr-defined]
+except AttributeError:  # pragma: no cover - ElementTree fallback
+    Element = etree.Element  # type: ignore[assignment]
+
+
+def load_xml(data: bytes) -> Element:
+    """Return the root XML element from *data*.
+
+    The XML is parsed using :mod:`defusedxml` to guard against common XML parser
+    exploits. All whitespace is preserved because Tableau workbooks are
+    whitespace sensitive in a few places (notably formula definitions).
+    """
+
+    if LXML_AVAILABLE:
+        parser = etree.XMLParser(remove_blank_text=False, resolve_entities=False)
+        return fromstring(data, parser=parser)
+    return fromstring(data)
+
+
+def dump_xml(root: Element) -> bytes:
+    """Serialise *root* into UTF-8 encoded bytes."""
+
+    if LXML_AVAILABLE:
+        return etree.tostring(root, encoding="utf-8", xml_declaration=True, pretty_print=True)  # type: ignore[arg-type]
+    return etree.tostring(root, encoding="utf-8")  # type: ignore[arg-type]
+
+
+def deep_copy_element(element: Element) -> Element:
+    """Return a deep copy of *element* preserving all sub-tree data."""
+
+    return fromstring(etree.tostring(element))
+
+
+@dataclass
+class IdRegistry:
+    """Track identifiers that appear in the workbook.
+
+    Tableau mixes GUID like identifiers with simple string identifiers. The
+    registry keeps a set of all identifiers that have been observed and can
+    generate a new identifier based on a preferred prefix.
+    """
+
+    known_ids: set[str]
+
+    def __init__(self, elements: Iterable[Element]) -> None:
+        self.known_ids = set()
+        for element in elements:
+            self._register_element(element)
+
+    def _register_element(self, element: Element) -> None:
+        id_attr = element.get("id")
+        if id_attr:
+            self.known_ids.add(id_attr)
+        for child in element:
+            self._register_element(child)
+
+    def reserve(self, identifier: str) -> None:
+        self.known_ids.add(identifier)
+
+    def ensure(self, identifier: str, prefix: str = "z") -> str:
+        if identifier in self.known_ids:
+            return self.new(prefix)
+        self.known_ids.add(identifier)
+        return identifier
+
+    def new(self, prefix: str = "z") -> str:
+        index = 1
+        candidate = f"{prefix}{index}"
+        while candidate in self.known_ids:
+            index += 1
+            candidate = f"{prefix}{index}"
+        self.known_ids.add(candidate)
+        return candidate
+
+
+def ensure_unique_id(element: Element, registry: IdRegistry, prefix: str = "z") -> str:
+    current = element.get("id")
+    if current:
+        unique = registry.ensure(current, prefix=prefix)
+        element.set("id", unique)
+        return unique
+    new_value = registry.new(prefix=prefix)
+    element.set("id", new_value)
+    return new_value
+
+
+def iter_elements(root: Element, tag: Optional[str] = None) -> Iterator[Element]:
+    for element in root.iter(tag):
+        yield element
+
+
+def xpath(element: Element, expression: str):
+    if LXML_AVAILABLE:
+        return element.xpath(expression)  # type: ignore[attr-defined]
+    return element.findall(expression)

--- a/tableau_workbook_editor/examples/modify_dashboard.py
+++ b/tableau_workbook_editor/examples/modify_dashboard.py
@@ -1,0 +1,26 @@
+"""Example script showing how to edit a workbook."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from tableau_workbook_editor import open_workbook
+
+
+def main(path: str) -> None:
+    workbook = open_workbook(Path(path))
+    workbook.rename_field(datasource="Orders", old="Profit", new="Net Profit")
+    workbook.add_calculation(
+        datasource="Orders",
+        name="Profit Ratio",
+        formula="SUM([Profit])/SUM([Sales])",
+        data_type="float",
+    )
+    workbook.save()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    import sys
+
+    if len(sys.argv) < 2:
+        raise SystemExit("Usage: python modify_dashboard.py <workbook>")
+    main(sys.argv[1])

--- a/tableau_workbook_editor/tests/fixtures/sample_workbook.twb
+++ b/tableau_workbook_editor/tests/fixtures/sample_workbook.twb
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<workbook>
+  <version value="2021.1" />
+  <datasources>
+    <datasource name="Orders" caption="Orders">
+      <column name="[Profit]" caption="Profit" datatype="float" role="measure" />
+      <column name="[Sales]" caption="Sales" datatype="float" role="measure" />
+      <column name="[Region]" caption="Region" datatype="string" role="dimension" />
+      <column name="[Category]" caption="Category" datatype="string" role="dimension" />
+      <connection class="sqlproxy" server="localhost" dbname="sample" schema="public" table="orders" />
+      <datasource-dependencies>
+        <column ref="[Profit]" />
+      </datasource-dependencies>
+    </datasource>
+  </datasources>
+  <worksheets>
+    <worksheet name="Summary">
+      <table>
+        <datasource name="Orders" />
+        <view>
+          <columns>
+            <column ref="[Profit]" />
+            <column ref="[Region]" />
+          </columns>
+        </view>
+      </table>
+      <zone id="ws1" />
+    </worksheet>
+    <worksheet name="Detail">
+      <table>
+        <datasource name="Orders" />
+        <view>
+          <columns>
+            <column ref="[Profit]" />
+          </columns>
+        </view>
+      </table>
+      <zone id="ws2" />
+    </worksheet>
+  </worksheets>
+  <dashboards>
+    <dashboard name="Executive">
+      <zones>
+        <zone id="root" type="layout" />
+        <zone id="z1" type="worksheet" worksheet="Summary" x="0" y="0" w="400" h="300" />
+      </zones>
+    </dashboard>
+  </dashboards>
+  <actions>
+    <action type="filter" name="Action1" source="Executive" target="Detail" mapping="Region=Region" />
+  </actions>
+  <parameters>
+    <parameter name="RegionParam" datatype="string" current-value="East">
+      <values>
+        <value>East</value>
+        <value>West</value>
+      </values>
+    </parameter>
+  </parameters>
+</workbook>

--- a/tableau_workbook_editor/tests/test_actions.py
+++ b/tableau_workbook_editor/tests/test_actions.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from tableau_workbook_editor import open_workbook
+from tableau_workbook_editor.core.xml_utils import xpath
+
+
+FIXTURE = Path(__file__).parent / "fixtures" / "sample_workbook.twb"
+
+
+def test_add_filter_action_appends_action() -> None:
+    wb = open_workbook(FIXTURE)
+    wb.add_filter_action(source="Executive", target="Detail", mapping={"Region": "Region", "Category": "Category"})
+    actions = xpath(wb.root, "./actions/action")
+    assert len(actions) == 2
+    new_action = actions[-1]
+    assert new_action.get("mapping") == "Region=Region; Category=Category"

--- a/tableau_workbook_editor/tests/test_calc_fields.py
+++ b/tableau_workbook_editor/tests/test_calc_fields.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import pytest
+
+from tableau_workbook_editor import open_workbook
+from tableau_workbook_editor.core.calc_utils import lint_calculation
+from tableau_workbook_editor.core.xml_utils import xpath
+
+from pathlib import Path
+
+FIXTURE = Path(__file__).parent / "fixtures" / "sample_workbook.twb"
+
+
+def test_add_calculation_appends_column() -> None:
+    wb = open_workbook(FIXTURE)
+    wb.add_calculation(datasource="Orders", name="Margin", formula="SUM([Profit]) - SUM([Sales])", data_type="float")
+    column = xpath(wb.root, "./datasources/datasource/column[@caption='Margin']")
+    assert column
+
+
+def test_lint_detects_unbalanced_parentheses() -> None:
+    result = lint_calculation("SUM([Profit]")
+    assert not result.ok
+    assert "Unbalanced" in result.message
+
+
+def test_add_calculation_rejects_invalid_formula() -> None:
+    wb = open_workbook(FIXTURE)
+    with pytest.raises(ValueError):
+        wb.add_calculation(datasource="Orders", name="Broken", formula="SUM([Profit]")

--- a/tableau_workbook_editor/tests/test_datasource_ops.py
+++ b/tableau_workbook_editor/tests/test_datasource_ops.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from tableau_workbook_editor import open_workbook
+from tableau_workbook_editor.core.xml_utils import xpath
+
+
+FIXTURE = Path(__file__).parent / "fixtures" / "sample_workbook.twb"
+
+
+def test_rename_field_updates_references(tmp_path: Path) -> None:
+    wb = open_workbook(FIXTURE)
+    wb.rename_field(datasource="Orders", old="Region", new="Geography")
+
+    worksheet_refs = xpath(wb.root, ".//worksheet//column[@ref='[Geography]']")
+    assert worksheet_refs
+    action = xpath(wb.root, "./actions/action[@name='Action1']")[0]
+    assert "Geography" in action.get("mapping", "")
+
+    saved = tmp_path / "rename.twb"
+    wb.save(path=saved)
+    reopened = open_workbook(saved)
+    assert xpath(reopened.root, ".//column[@caption='Geography']")
+
+
+def test_set_connection_updates_connection_node() -> None:
+    wb = open_workbook(FIXTURE)
+    wb.set_connection(datasource="Orders", server="server", db="warehouse", schema="analytics", table="orders")
+    connection = xpath(wb.root, "./datasources/datasource/connection")[0]
+    assert connection.get("server") == "server"
+    assert connection.get("dbname") == "warehouse"
+    assert connection.get("schema") == "analytics"
+    assert connection.get("table") == "orders"

--- a/tableau_workbook_editor/tests/test_devices.py
+++ b/tableau_workbook_editor/tests/test_devices.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from tableau_workbook_editor import open_workbook
+from tableau_workbook_editor.core import dashboards, devices
+
+
+FIXTURE = Path(__file__).parent / "fixtures" / "sample_workbook.twb"
+
+
+def test_list_device_layouts_handles_missing_nodes() -> None:
+    wb = open_workbook(FIXTURE)
+    dashboard = dashboards.find_dashboard(wb.root, "Executive")
+    assert dashboard is not None
+    layouts = devices.list_device_layouts(dashboard)
+    assert layouts == []

--- a/tableau_workbook_editor/tests/test_diffs.py
+++ b/tableau_workbook_editor/tests/test_diffs.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from tableau_workbook_editor import open_workbook
+
+
+FIXTURE = Path(__file__).parent / "fixtures" / "sample_workbook.twb"
+
+
+def test_diff_reports_modifications() -> None:
+    wb = open_workbook(FIXTURE)
+    assert wb.diff() == []
+    wb.rename_field(datasource="Orders", old="Profit", new="Net Profit")
+    diff = wb.diff()
+    assert diff == ["Workbook modified"]

--- a/tableau_workbook_editor/tests/test_layouts.py
+++ b/tableau_workbook_editor/tests/test_layouts.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from tableau_workbook_editor import open_workbook
+from tableau_workbook_editor.core.xml_utils import xpath
+
+
+FIXTURE = Path(__file__).parent / "fixtures" / "sample_workbook.twb"
+
+
+def test_move_zone_updates_geometry() -> None:
+    wb = open_workbook(FIXTURE)
+    wb.move_zone(dashboard="Executive", zone_id="z1", x=40, y=80, w=600, h=300)
+    zone = xpath(wb.root, "./dashboards/dashboard[@name='Executive']/zones/zone[@id='z1']")[0]
+    assert zone.get("x") == "40"
+    assert zone.get("y") == "80"
+    assert zone.get("w") == "600"
+    assert zone.get("h") == "300"
+
+
+def test_add_sheet_creates_new_zone() -> None:
+    wb = open_workbook(FIXTURE)
+    wb.add_sheet_to_dashboard(dashboard="Executive", sheet="Detail", floating=True, container="root", index=10)
+    zones = xpath(wb.root, "./dashboards/dashboard[@name='Executive']/zones/zone[@worksheet='Detail']")
+    assert zones

--- a/tableau_workbook_editor/tests/test_parameters.py
+++ b/tableau_workbook_editor/tests/test_parameters.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from tableau_workbook_editor import open_workbook
+from tableau_workbook_editor.core.xml_utils import xpath
+
+
+FIXTURE = Path(__file__).parent / "fixtures" / "sample_workbook.twb"
+
+
+def test_set_parameter_updates_values() -> None:
+    wb = open_workbook(FIXTURE)
+    wb.set_parameter(name="RegionParam", data_type="string", value="Central", allowable_values=["Central", "East"], display_format="string")
+    parameter = xpath(wb.root, "./parameters/parameter[@name='RegionParam']")[0]
+    assert parameter.get("current-value") == "Central"
+    assert parameter.get("display-format") == "string"
+    values = [v.text for v in xpath(parameter, "./values/value")]
+    assert values == ["Central", "East"]
+
+
+def test_create_parameter_when_missing() -> None:
+    wb = open_workbook(FIXTURE)
+    wb.set_parameter(name="Threshold", data_type="integer", value="5")
+    param = xpath(wb.root, "./parameters/parameter[@name='Threshold']")
+    assert param

--- a/tableau_workbook_editor/tests/test_roundtrip.py
+++ b/tableau_workbook_editor/tests/test_roundtrip.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from tableau_workbook_editor import open_workbook
+from tableau_workbook_editor.core.xml_utils import xpath
+
+
+FIXTURE = Path(__file__).parent / "fixtures" / "sample_workbook.twb"
+
+
+def test_roundtrip(tmp_path: Path) -> None:
+    wb = open_workbook(FIXTURE)
+    wb.rename_field(datasource="Orders", old="Profit", new="Net Profit")
+    wb.add_calculation(datasource="Orders", name="Profit Ratio", formula="SUM([Profit])/SUM([Sales])", data_type="float")
+    wb.set_parameter(
+        name="RegionParam",
+        data_type="string",
+        value="West",
+        allowable_values=["East", "West", "Central"],
+    )
+    wb.add_sheet_to_dashboard(dashboard="Executive", sheet="Detail", floating=False, container="root", index=1)
+    wb.add_filter_action(source="Executive", target="Detail", mapping={"Region": "Region"})
+    wb.set_connection(datasource="Orders", server="analytics.example.com", db="sales", schema="public", table="orders")
+
+    output = tmp_path / "modified.twb"
+    wb.save(path=output)
+
+    reopened = open_workbook(output)
+    columns = xpath(reopened.root, "./datasources/datasource/column[@caption='Net Profit']")
+    assert columns
+    parameter = xpath(reopened.root, "./parameters/parameter[@name='RegionParam']")[0]
+    values = [v.text for v in xpath(parameter, "./values/value")]
+    assert values == ["East", "West", "Central"]
+    action = xpath(reopened.root, "./actions/action[@type='filter']")
+    assert len(action) == 2


### PR DESCRIPTION
## Summary
- implement a Tableau workbook editor core with safe XML handling, datasource/worksheet operations, and validation helpers
- add a CLI, README, project metadata, and examples for working with workbooks
- create synthetic fixtures and pytest-based coverage for round-tripping, field edits, parameters, layouts, actions, and diffs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd1b8ca4e083319edf24431c20031f